### PR TITLE
Add Bastion public IP to the Outputs

### DIFF
--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -223,3 +223,6 @@ Outputs:
     Value: !GetAtt VPCStack.Outputs.VPCID
     Export:
       Name: 'ATL-VPCID'
+  BastionPubIp:
+    Description: The Public IP to ssh to the Bastion
+    Value: !GetAtt 'BastionStack.Outputs.BastionPubIp'


### PR DESCRIPTION
Currently, the Bastion IP is hidden in the nested stack which makes it impossible to expose in the parent product stack (because it is 2 layers deep). This change will allow us to display Bastion IP in the master stack which might be very useful when debugging is required.