### PR TITLE
DCD-345: Move from static AMI IDs for bastion

### DIFF
--- a/quickstarts/quickstart-bastion-for-atlassian-services.yaml
+++ b/quickstarts/quickstart-bastion-for-atlassian-services.yaml
@@ -9,16 +9,14 @@ Metadata:
         Parameters: [VPC, Subnet, AccessCIDR, KeyName]
       - Label:
           default: 'Linux Bastion Configuration'
-        Parameters: [EnableTCPForwarding, EnableX11Forwarding]
+        Parameters: [LatestAmiId]
     ParameterLabels:
       AccessCIDR:
         default: IP range Permitted Access
-      EnableTCPForwarding:
-        default: Enable TCP Forwarding
-      EnableX11Forwarding:
-        default: Enable X11 Forwarding
       KeyName:
         default: Key Name *
+      LatestAmiId:
+        default: System property with AMI ID
       Subnet:
         default: External subnet *
       VPC:
@@ -32,24 +30,14 @@ Parameters:
     Type: String
     MinLength: 9
     MaxLength: 18
-  EnableTCPForwarding:
-    Type: String
-    Description: Enable/Disable TCP Forwarding
-    Default: 'true'
-    AllowedValues:
-      - 'true'
-      - 'false'
-  EnableX11Forwarding:
-    Type: String
-    Description: Enable/Disable X11 Forwarding
-    Default: 'false'
-    AllowedValues:
-      - 'true'
-      - 'false'
   KeyName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances
+    Description: The EC2 Key Pair to allow SSH access to the instances.
     Type: AWS::EC2::KeyPair::KeyName
+  LatestAmiId:
+    Default: '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2'
+    Description: (leave default) System property containing AMI ID for the Bastion host.
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
   Subnet:
     ConstraintDescription: Must be one of the external Subnet ID's within the selected VPC.
     Description: External Subnet where your bastion will be deployed. MUST be within the selected VPC.
@@ -59,48 +47,15 @@ Parameters:
     Description: Virtual Private Cloud
     Type: "AWS::EC2::VPC::Id"
 
-Mappings:
-  RegionAmiMap:
-    ap-northeast-1:
-      "ami": "ami-06cd52961ce9f0d85"
-    ap-northeast-2:
-      "ami": "ami-0a10b2721688ce9d2"
-    ap-south-1:
-      "ami": "ami-0912f71e06545ad88"
-    ap-southeast-1:
-      "ami": "ami-08569b978cc4dfa10"
-    ap-southeast-2:
-      "ami": "ami-09b42976632b27e9b"
-    ca-central-1:
-      "ami": "ami-0b18956f"
-    eu-central-1:
-      "ami": "ami-0233214e13e500f77"
-    eu-west-1:
-      "ami": "ami-047bb4163c506cd98"
-    eu-west-2:
-      "ami": "ami-f976839e"
-    eu-west-3:
-      "ami": "ami-0ebc281c20e89ba4b"
-    sa-east-1:
-      "ami": "ami-07b14488da8ea02a0"
-    us-east-1:
-      "ami": "ami-0ff8a91507f77f867"
-    us-east-2:
-      "ami": "ami-0b59bfac6be064b78"
-    us-west-1:
-      "ami": "ami-0bdb828fd58c52235"
-    us-west-2:
-      "ami": "ami-a0cfeed8"
-
 Resources:
   Bastion:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: !FindInMap [RegionAmiMap, !Ref "AWS::Region", "ami"]
+      ImageId: !Ref LatestAmiId
       InstanceType: t2.micro
       KeyName: !Ref KeyName
       NetworkInterfaces:
-        - AssociatePublicIpAddress: "true"
+        - AssociatePublicIpAddress: true
           DeviceIndex: "0"
           GroupSet: [ !Ref SecurityGroup ]
           SubnetId: !Ref Subnet


### PR DESCRIPTION
Use dynamic IDs fetched from system property manager.
Fixes https://alas.aws.amazon.com/ALAS-2019-1205.html