### PR TITLE
Update param language to refer to Aurora as "Amazon Aurora" instead of "AWS Aurora"

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -5,10 +5,10 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: RDS Bootstrap template for use with Atlassian Services
 Parameters:
   DatabaseImplementation:
-    Default: 'AWS Aurora PostgreSQL'
-    Description: 'Database Engine to use. PostgreSQL or AWS Aurora Clustered PostgreSQL'
+    Default: 'Amazon Aurora PostgreSQL'
+    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora Clustered PostgreSQL'
     AllowedValues:
-      - 'AWS Aurora PostgreSQL'
+      - 'Amazon Aurora PostgreSQL'
       - 'PostgreSQL'
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
@@ -46,25 +46,25 @@ Parameters:
       - db.t2.xlarge
       - db.t2.2xlarge
     ConstraintDescription: Must be a valid RDS instance class from the list
-    Description: RDS instance type (must be r4 family if using Aurora)
+    Description: RDS instance type (must be r4 family if using Amazon Aurora)
     Type: String
   DBIops:
     Default: 1000
     ConstraintDescription: Must be in the range 1000 - 30000.
-    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00. Not valid for Aurora'
+    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00. Not used for Amazon Aurora.'
     MinValue: 1000
     MaxValue: 30000
     Type: Number
   DBMasterUserPassword:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
     ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol
-    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol.
     MinLength: 8
     MaxLength: 128
     NoEcho: true
     Type: String
   DBMultiAZ:
-    Description: When DBEngine is 'PostgreSQL', this will determine whether to provision a multi-AZ RDS instance. When DBEngine is 'AWS Aurora PostgreSQL', this will determine whether to provision a single or a multi node Aurora cluster
+    Description: When DBEngine is 'PostgreSQL', this will determine whether to provision a multi-AZ RDS instance. When DBEngine is 'Amazon Aurora PostgreSQL', this will determine whether to provision a single or a multi node Amazon Aurora cluster.
     Default: true
     AllowedValues:
       - true
@@ -73,7 +73,7 @@ Parameters:
     Type: String
   DBAllocatedStorage:
     Default: 10
-    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144. Not valid for Aurora
+    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144. Not used for Amazon Aurora.
     Type: Number
   DBStorageEncrypted:
     Default: false
@@ -88,7 +88,7 @@ Parameters:
       - General Purpose (SSD)
       - Provisioned IOPS
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
-    Description: Database storage type. Not valid for Aurora.
+    Description: Database storage type. Not used for Amazon Aurora.
     Type: String
   QSS3BucketName:
     Default: 'aws-quickstart'
@@ -112,7 +112,7 @@ Parameters:
 
 Conditions:
     UseAurora:
-      !Equals [!Ref DatabaseImplementation, 'AWS Aurora PostgreSQL']
+      !Equals [!Ref DatabaseImplementation, 'Amazon Aurora PostgreSQL']
     UsePostgres:
       !Equals [!Ref DatabaseImplementation, 'PostgreSQL']
     GovCloudCondition:

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -133,6 +133,7 @@ Resources:
         DBBackupRetentionPeriod: !Ref DBBackupRetentionPeriod
         DBInstanceClass: !Ref DBInstanceClass
         DBMasterUsername: postgres
+        DBEngineVersion: 9.6.11
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
         DBName: ''


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
