### PR TITLE
Update version of Amazon aurora submodule.

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -150,7 +150,7 @@ Resources:
         DBBackupRetentionPeriod: !Ref DBBackupRetentionPeriod
         DBInstanceClass: !Ref DBInstanceClass
         DBMasterUsername: postgres
-        DBEngineVersion: 9.6.11
+        DBEngineVersion: 9.6.12
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
         DBName: ''


### PR DESCRIPTION
The current version of Aurora template doesn't have the 9.6.12 db parameter group mapping which is causing all aurora deploys to fail. This updates the version to include the aurora template including the new mapping.