### PR TITLE
DCD-528: Disable event subscription by default

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -2,7 +2,7 @@
 # This template is a wrapper for compatible database templates. It exposes a single input/output API and can be referenced the same way no
 # matter which Database "Implementation" is chosen.
 AWSTemplateFormatVersion: 2010-09-09
-Description: RDS Bootstrap template for use with Atlassian Services
+Description: RDS Bootstrap template for use with Atlassian Services (qs-1pj6s43hc)
 Parameters:
   DatabaseImplementation:
     Default: 'Amazon Aurora PostgreSQL'

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -15,7 +15,7 @@
 # DBAllocatedStorageEncrypted
 # DBStorageType
 AWSTemplateFormatVersion: 2010-09-09
-Description: RDS Postgres Database for use in Atlassian Standard Infrastructure
+Description: RDS Postgres Database for use in Atlassian Standard Infrastructure (qs-1aj6s44e4)
 Parameters:
   DBAutoMinorVersionUpgrade:
     Default: true


### PR DESCRIPTION
Previously the nested Aurora template was creating `AWS::RDS::EventSubscription` by default which caused issues when deleting the stacks with unconfirmed subscriptions. As we haven't changed `NotificationList` parameter, it always used `db-ops@domain.com` email address to send a confirmation email and waited for somebody confirming the email (which never happened).

This PR updates the Aurora submodule and also disables the event subscription.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
