### PR TITLE
DCD-596: Add Export prefix and default taskcat params

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+templates:
+  - templates/*

--- a/ci/params/default/quickstart-asi-custom-export.json
+++ b/ci/params/default/quickstart-asi-custom-export.json
@@ -1,0 +1,26 @@
+[
+    {
+        "ParameterKey":"QSS3BucketName",
+        "ParameterValue":"$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey":"QSS3KeyPrefix",
+        "ParameterValue":"quickstart-atlassian-services/"
+    },
+    {
+        "ParameterKey": "AvailabilityZones",
+        "ParameterValue": "$[taskcat_genaz_2]"
+    },
+    {
+        "ParameterKey": "AccessCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "ExportPrefix",
+        "ParameterValue": "CUSTOM"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    }
+]

--- a/ci/params/default/taskcat.yml
+++ b/ci/params/default/taskcat.yml
@@ -18,7 +18,7 @@ global:
 
 tests:
   vpc:
-    parameter_input: quickstat-vpc-for-atlassian-services-inputs.json
+    parameter_input: params/default/quickstart-asi-custom-export.json
     template_file: quickstart-vpc-for-atlassian-services.yaml
     regions:
       - us-east-1

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -122,44 +122,6 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
-Mappings:
-  AWSInfoRegionMap:
-    ap-northeast-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-northeast-2:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-south-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-southeast-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-southeast-2:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    eu-central-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    eu-west-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    sa-east-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    us-east-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    us-gov-west-1:
-      Partition: aws-us-gov
-      QuickStartS3URL: https://s3-us-gov-west-1.amazonaws.com
-    us-west-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    us-west-2:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
 Resources:
   VPCStack:
     Type: AWS::CloudFormation::Stack
@@ -185,8 +147,6 @@ Resources:
         VPCCIDR: !Ref 'VPCCIDR'
   BastionStack:
     Type: AWS::CloudFormation::Stack
-    DependsOn:
-      - VPCStack
     Properties:
       TemplateURL: !Sub
         - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}quickstarts/quickstart-bastion-for-atlassian-services.yaml

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -22,6 +22,7 @@ Metadata:
       - Label:
           default: AWS Quick Start Configuration
         Parameters:
+          - ExportPrefix
           - QSS3BucketName
           - QSS3KeyPrefix
     ParameterLabels:
@@ -29,6 +30,8 @@ Metadata:
         default: Permitted IP Range
       AvailabilityZones:
         default: Availability Zones
+      ExportPrefix:
+        default: Export variable prefix
       KeyPairName:
         default: Key Name
       NATInstanceType:
@@ -48,10 +51,19 @@ Metadata:
       VPCCIDR:
         default: VPC CIDR
 Parameters:
+  AccessCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR block allowed to access Atlassian Services. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
+    Type: String
   AvailabilityZones:
     Description: 'List of Availability Zones to use for the subnets in the VPC. Note: You must specify 2 AZs here; 
       if more are specified only the first 2 will be used.'
     Type: List<AWS::EC2::AvailabilityZone::Name>
+  ExportPrefix:
+    Default: ATL-
+    Description: Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS
+      Quickstarts.
+    Type: String
   KeyPairName:
     Description: Public/private key pairs allow you to securely connect to your instance
       after it launches
@@ -114,10 +126,6 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
     Type: String
-  AccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR block allowed to access Atlassian Services. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
-    Type: String
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
@@ -164,22 +172,22 @@ Outputs:
     Description: Default Ec2 keypair name
     Value: !Ref 'KeyPairName'
     Export:
-      Name: 'ATL-DefaultKey'
+      Name: !Sub '${ExportPrefix}DefaultKey'
   PrivateSubnets:
     Description: A list of 2 Private subnets
     Value: !Join [ ',', [ !GetAtt VPCStack.Outputs.PrivateSubnet1AID, !GetAtt VPCStack.Outputs.PrivateSubnet2AID ]]
     Export:
-      Name: 'ATL-PriNets'
+      Name: !Sub '${ExportPrefix}PriNets'
   PublicSubnets:
     Description: A list of 2 Public subnets
     Value: !Join [ ',', [ !GetAtt VPCStack.Outputs.PublicSubnet1ID, !GetAtt VPCStack.Outputs.PublicSubnet2ID ]]
     Export:
-      Name: 'ATL-PubNets'
+      Name: !Sub '${ExportPrefix}PubNets'
   VPCID:
     Description: Atlassian Services VPC ID
     Value: !GetAtt VPCStack.Outputs.VPCID
     Export:
-      Name: 'ATL-VPCID'
+      Name: !Sub '${ExportPrefix}VPCID'
   BastionPubIp:
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt 'BastionStack.Outputs.BastionPubIp'


### PR DESCRIPTION
* Added default taskcat file that is used in our Bamboo builds
* We are now using `us-east-1` which is closest to our Bamboo builds (and cheapest)
* Added `ExportPrefix` parameter that allows us to use a different prefix for exported variables. For now, I haven't changed the product templates to add this one more parameter to them but I think it is a good feature to have. This will require documentation changes, @ddomingorh.

Build 💚: https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSSERVICES0-15