### PR TITLE
Create a simple CloudWatch dashboard template

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,2 +1,2 @@
 templates:
-  - templates/*
+  - templates/*.yaml

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,23 @@
+## Developing `quickstart-atlassian-services`
+This repository contains templates that are used to provide shared infrastructure components for [atlassian quickstart templates](https://aws.amazon.com/quickstart/?quickstart-all.sort-by=item.additionalFields.updateDate&quickstart-all.sort-order=desc&quickstart-all.q=atlassian&quickstart-all.q_operator=AND)
+
+Additionally, this repository uses `git submodules` to reference other shared infrastructure templates.
+
+### Getting started
+
+Most templates within the `templates` directory (except for `quickstart-cloudwatch-dashboard.yaml`), can be directly edited, tested (using `cfn-lint`) and deployed to AWS.
+
+##### CloudWatch template
+The CloudWatch template (`templates/quickstart-cloudwatch-dashboard.yaml`) creates a simple CloudWatch dashboard to visualize a few common metrics and logs. The purpose of this template is to provide a starting point for customers to view necessary metrics and logs that are relevant to their deployment. When a developer wants to update the `CloudWatch` dashboard, the following steps have to be executed in this order -
+
+1. The Dashboard config (`templates/config/dashboard_config.json`) is a JSON file describing the CloudWatch dashboard configuration. This file has to be updated with a valid dashboard configuration JSON document. See [this page](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html) for the correct structure and syntax.
+2. If desired, the template definition `quickstart-cloudwatch-dashboard.yaml.template` may be updated to define/edit/remove resources, conditions, parameters, outputs and other cloudformation primitives. 
+`Note: The template defines a marker string called DASHBOARD_CONFIG which will be replaced by the contents of the dashboard configuration JSON in the next step` 
+3. Run `make create_dashboard_template` from the project root directory. This command updates the template (`templates/quickstart-cloudwatch-dashboard.yaml`) using the dashboard configuration and the template definition.
+4. Lint & test the generated template with `cfn-lint templates/<template_name>`
+5. If successful, commit all 3 files - the config, template definition and the generated template.   
+
+
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+MAKEFILE := $(lastword $(MAKEFILE_LIST))
+PWD := $(patsubst %/,%,$(dir $(abspath $(MAKEFILE))))
+
+DASHBOARD_TEMPLATE_NAME = quickstart-cloudwatch-dashboard.yaml
+DASHBOARD_CONFIG_NAME = cloudwatch_dashboard_config.json
+
+DASHBOARD_CONFIG_FILE := $(PWD)/templates/config/$(DASHBOARD_CONFIG_NAME)
+DASHBOARD_TEMPLATE_FILE := $(PWD)/templates/config/$(DASHBOARD_TEMPLATE_NAME).template
+DASHBOARD_TEMPLATE := $(PWD)/templates/$(DASHBOARD_TEMPLATE_NAME)
+
+
+define prettyecho
+        $(if $(TERM),
+                @tput setaf $2
+                @echo $1
+                @tput sgr0,
+                @echo $1)
+endef
+
+create_dashboard_template:
+		@echo
+		$(call prettyecho, "Reading contents of - $(DASHBOARD_CONFIG_FILE) and replacing marker in $(DASHBOARD_TEMPLATE_FILE)", 13)
+		# The following command replaces the text 'DASHBOAD_CONFIG' in the template file 
+		# with content present in the cloudwatch dashboad configurartion file
+		# and writes the output to the cloudwatch template under templates/ directory
+		cat $(DASHBOARD_TEMPLATE_FILE) | sed -e s~DASHBOARD_CONFIG~'$(shell cat $(DASHBOARD_CONFIG_FILE) | tr -s "[:space:]" | tr -d "\t" | tr -d "\n")'~g > $(DASHBOARD_TEMPLATE)
+		$(call prettyecho, "Template created at - $(DASHBOARD_TEMPLATE). Contents are -", 13)
+		cat $(DASHBOARD_TEMPLATE)
+		@echo
+
+verify_dashboard_checksum:
+	@echo
+	$(eval GENERATED_MD5 := $(shell cat $(DASHBOARD_TEMPLATE_FILE) | sed -e s~DASHBOARD_CONFIG~'$(shell cat $(DASHBOARD_CONFIG_FILE) | tr -s "[:space:]" | tr -d "\t" | tr -d "\n")'~g | md5))
+	$(eval ACTUAL_MD5 := $(shell cat $(DASHBOARD_TEMPLATE) | md5))
+	@if [ "$(GENERATED_MD5)" == "$(ACTUAL_MD5)" ]; then echo "MD5 matches"; else echo "MD5 Mismatch!! Throwing error" && exit -2; fi;
+	@echo
+

--- a/templates/config/cloudwatch_dashboard_config.json
+++ b/templates/config/cloudwatch_dashboard_config.json
@@ -1,0 +1,82 @@
+{
+  "start": "-PT3H",
+  "periodOverride": "inherit",
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 0,
+      "width": 24,
+      "height": 6,
+      "properties": {
+        "view": "singleValue",
+        "stacked": false,
+        "metrics": [
+          [ "AWS/EC2", "StatusCheckFailed_System", "AutoScalingGroupName", "${AsgToMonitor}"],
+          [ ".", "StatusCheckFailed", ".", "." ],
+          [ ".", "StatusCheckFailed_Instance", ".", "." ],
+          [ ".", "EBSIOBalance%", ".", "." ],
+          [ ".", "EBSByteBalance%", ".", "." ],
+          [ ".", "EBSReadOps", ".", "." ],
+          [ ".", "EBSReadBytes", ".", "." ],
+          [ ".", "EBSWriteOps", ".", "." ],
+          [ ".", "EBSWriteBytes", ".", "." ],
+          [ ".", "CPUUtilization", ".", "." ],
+          [ ".", "NetworkIn", ".", "." ],
+          [ ".", "NetworkOut", ".", "." ],
+          [ ".", "NetworkPacketsIn", ".", "." ],
+          [ ".", "NetworkPacketsOut", ".", "." ]
+        ],
+        "region": "${AWS::Region}"
+      }
+    },
+    {
+      "type": "log",
+      "x": 0,
+      "y": 6,
+      "width": 24,
+      "height": 6,
+      "properties": {
+        "query": "SOURCE \\\"${ProductFamilyName}-${ProductStackName}\\\" | fields @timestamp, @message | sort @timestamp desc | limit 20",
+        "region": "${AWS::Region}",
+        "stacked": false,
+        "title": "Log group: ${ProductFamilyName}-${ProductStackName}",
+        "view": "table"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 15,
+      "y": 12,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "metrics": [
+          [ "AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", "${DatabaseIdentifier}" ]
+        ],
+        "region": "${AWS::Region}"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 12,
+      "width": 15,
+      "height": 6,
+      "properties": {
+        "view": "singleValue",
+        "metrics": [
+          [ "AWS/RDS", "WriteThroughput", "DBInstanceIdentifier", "${DatabaseIdentifier}" ],
+            [ ".", "WriteLatency", ".", "." ],
+            [ ".", "ReadLatency", ".", "." ],
+            [ ".", "ReadThroughput", ".", "." ],
+            [ ".", "WriteIOPS", ".", "." ],
+            [ ".", "ReadIOPS", ".", "." ]
+          ],
+          "region": "${AWS::Region}"
+      }
+    }
+  ]
+}

--- a/templates/config/quickstart-cloudwatch-dashboard.yaml.template
+++ b/templates/config/quickstart-cloudwatch-dashboard.yaml.template
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Cloudwatch dashboard template
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Cloudwatch Dashboard Configuration
+        Parameters:
+          - ProductStackName
+          - ProductFamilyName
+          - AsgToMonitor
+          - DatabaseIdentifier
+
+Parameters:
+  ProductStackName:
+    Description: "Product stack name"
+    Type: "String"
+  ProductFamilyName:
+    Description: "Name of the product family being deployed"
+    Type: "String"
+  AsgToMonitor:
+    Description: "Name of the ASG to monitor"
+    Type: "String"
+  DatabaseIdentifier:
+    Description: "Identifier of database to monitor"
+    Type: "String"
+
+Resources:
+  Dashboard:
+    Type: "AWS::CloudWatch::Dashboard"
+    Properties:
+      DashboardName: !Sub ["${StackName}-dashboard", {StackName: !Ref 'ProductStackName'}]
+      DashboardBody: !Sub |
+        DASHBOARD_CONFIG
+
+
+Outputs:
+  Dashboard:
+    Description: "Basic Monitoring dashboard"
+    Value: !Sub
+      - https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home#dashboards:name=${DashboardName}-dashboard
+      - DashboardName: !Ref ProductStackName

--- a/templates/quickstart-cloudwatch-dashboard.yaml
+++ b/templates/quickstart-cloudwatch-dashboard.yaml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Cloudwatch dashboard template
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Cloudwatch Dashboard Configuration
+        Parameters:
+          - ProductStackName
+          - ProductFamilyName
+          - AsgToMonitor
+          - DatabaseIdentifier
+
+Parameters:
+  ProductStackName:
+    Description: "Product stack name"
+    Type: "String"
+  ProductFamilyName:
+    Description: "Name of the product family being deployed"
+    Type: "String"
+  AsgToMonitor:
+    Description: "Name of the ASG to monitor"
+    Type: "String"
+  DatabaseIdentifier:
+    Description: "Identifier of database to monitor"
+    Type: "String"
+
+Resources:
+  Dashboard:
+    Type: "AWS::CloudWatch::Dashboard"
+    Properties:
+      DashboardName: !Sub ["${StackName}-dashboard", {StackName: !Ref 'ProductStackName'}]
+      DashboardBody: !Sub |
+        { "start": "-PT3H", "periodOverride": "inherit", "widgets": [ { "type": "metric", "x": 0, "y": 0, "width": 24, "height": 6, "properties": { "view": "singleValue", "stacked": false, "metrics": [ [ "AWS/EC2", "StatusCheckFailed_System", "AutoScalingGroupName", "${AsgToMonitor}"], [ ".", "StatusCheckFailed", ".", "." ], [ ".", "StatusCheckFailed_Instance", ".", "." ], [ ".", "EBSIOBalance%", ".", "." ], [ ".", "EBSByteBalance%", ".", "." ], [ ".", "EBSReadOps", ".", "." ], [ ".", "EBSReadBytes", ".", "." ], [ ".", "EBSWriteOps", ".", "." ], [ ".", "EBSWriteBytes", ".", "." ], [ ".", "CPUUtilization", ".", "." ], [ ".", "NetworkIn", ".", "." ], [ ".", "NetworkOut", ".", "." ], [ ".", "NetworkPacketsIn", ".", "." ], [ ".", "NetworkPacketsOut", ".", "." ] ], "region": "${AWS::Region}" } }, { "type": "log", "x": 0, "y": 6, "width": 24, "height": 6, "properties": { "query": "SOURCE \"${ProductFamilyName}-${ProductStackName}\" | fields @timestamp, @message | sort @timestamp desc | limit 20", "region": "${AWS::Region}", "stacked": false, "title": "Log group: ${ProductFamilyName}-${ProductStackName}", "view": "table" } }, { "type": "metric", "x": 15, "y": 12, "width": 9, "height": 6, "properties": { "view": "timeSeries", "stacked": false, "metrics": [ [ "AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", "${DatabaseIdentifier}" ] ], "region": "${AWS::Region}" } }, { "type": "metric", "x": 0, "y": 12, "width": 15, "height": 6, "properties": { "view": "singleValue", "metrics": [ [ "AWS/RDS", "WriteThroughput", "DBInstanceIdentifier", "${DatabaseIdentifier}" ], [ ".", "WriteLatency", ".", "." ], [ ".", "ReadLatency", ".", "." ], [ ".", "ReadThroughput", ".", "." ], [ ".", "WriteIOPS", ".", "." ], [ ".", "ReadIOPS", ".", "." ] ], "region": "${AWS::Region}" } } ]}
+
+
+Outputs:
+  Dashboard:
+    Description: "Basic Monitoring dashboard"
+    Value: !Sub
+      - https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home#dashboards:name=${DashboardName}-dashboard
+      - DashboardName: !Ref ProductStackName


### PR DESCRIPTION
*Description of changes:*

This PR adds the ability to create a simple CloudWatch dashboard. This template will be invoked from the product when cloudwatch is enabled (optional CFn parameter).

The cloudformation template is generated by using a dashboard configuration JSON document and a template definition file. Template generation is automated through the use of a Makefile.

The dashboard itself is a sample dashboard that customers are expected to further customize. Currently, it displays CPU, FS and memory stats, DB connection and latency overview and an unfiltered display of all logs inside a log group.

See the attached screenshot for a quick overview

<img width="1485" alt="Screenshot 2019-09-20 at 15 19 58" src="https://user-images.githubusercontent.com/1063972/65301392-9fa06600-dbba-11e9-8754-e27dee0f97fb.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
