### PR TITLE
DCD-466: Export NAT Gateways IPs

### DIFF
--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -3,37 +3,24 @@ global:
   owner: quickstart-eng@amazon.com
   qsname: quickstart-atlassian-services
   regions:
-    - ap-northeast-1
-    - ap-northeast-2
-    - ap-south-1
-    - ap-southeast-1
-    - ap-southeast-2
-    - eu-central-1
-    - eu-west-1
-    - sa-east-1
-    - us-east-1
-    - us-west-1
     - us-west-2
+    - ap-south-1
+    - eu-west-1
+    - us-east-1
+    - ca-central-1
+    - ap-northeast-1
+    - ap-southeast-2
+    - ap-southeast-1
+    - ap-northeast-2
+    - us-east-2
+    - eu-west-2
+    - eu-central-1
+    - us-west-1
+    - sa-east-1
+    - eu-west-3
   reporting: true
 
 tests:
   atlassian-vpc:
     parameter_input: quickstat-vpc-for-atlassian-services-inputs.json
     template_file: quickstart-vpc-for-atlassian-services.yaml
-    regions:
-      - us-west-2
-      - ap-south-1
-      - eu-west-1 
-      - us-east-1
-      - ca-central-1
-      - ap-northeast-1
-      - ap-southeast-2
-      - ap-southeast-1
-      - ap-northeast-2
-      - us-east-2
-      - eu-west-2
-      - eu-central-1
-      - us-west-1
-      - sa-east-1
-      - eu-west-3
-

--- a/templates/quickstart-bastion-for-atlassian-services.yaml
+++ b/templates/quickstart-bastion-for-atlassian-services.yaml
@@ -52,7 +52,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref LatestAmiId
-      InstanceType: t2.micro
+      InstanceType: t3.micro
       KeyName: !Ref KeyName
       NetworkInterfaces:
         - AssociatePublicIpAddress: true

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -10,7 +10,7 @@ Parameters:
     AllowedValues:
       - 'Amazon Aurora PostgreSQL'
       - 'PostgreSQL'
-    ConstraintDescription: Must be 'true' or 'false'.
+    ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBSecurityGroup:
     Description: "ID of the security group (e.g. sg-0234se). One will be created for you if left empty."

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -131,7 +131,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+      Each Atlassian Standard Infrastructure (ASI) uses a unique identifier. If you have multiple ASIs within the same AWS region, use this field to specify where to deploy the DB.
     Type: String
 
 Conditions:

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -16,14 +16,14 @@ Parameters:
     Description: "ID of the security group (e.g. sg-0234se). One will be created for you if left empty."
     Type: String
     Default: ''
-  DBAutoMinorVersionUpgrade: 
-    AllowedValues: 
+  DBAutoMinorVersionUpgrade:
+    AllowedValues:
       - "true"
       - "false"
     Default: "false"
     Description: "Select true/false to setup Auto Minor Version upgrade. e.g. PostgreSQL 9.6.8 -> 9.6.11"
     Type: String
-  DBBackupRetentionPeriod: 
+  DBBackupRetentionPeriod:
     Default: "7"
     Description: "The number of days for which automatic database snapshots are retained."
     Type: String
@@ -128,26 +128,31 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
     Type: String
+  ExportPrefix:
+    Default: 'ATL-'
+    Description:
+      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+    Type: String
 
 Conditions:
-    UseAurora:
-      !Equals [!Ref DatabaseImplementation, 'Amazon Aurora PostgreSQL']
-    UsePostgres:
-      !Equals [!Ref DatabaseImplementation, 'PostgreSQL']
-    GovCloudCondition:
-      !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
-    UseDatabaseEncryption:
-      !Equals [!Ref DBStorageEncrypted, true]
+  UseAurora:
+    !Equals [!Ref DatabaseImplementation, 'Amazon Aurora PostgreSQL']
+  UsePostgres:
+    !Equals [!Ref DatabaseImplementation, 'PostgreSQL']
+  GovCloudCondition:
+    !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+  UseDatabaseEncryption:
+    !Equals [!Ref DBStorageEncrypted, true]
 
 Resources:
   AuroraDatabase:
     Type: AWS::CloudFormation::Stack
     Condition: UseAurora
     Properties:
-      TemplateURL: 
+      TemplateURL:
         !Sub
-          - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
-          - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
       Parameters:
         CustomDBSecurityGroup: !Ref DBSecurityGroup
         DBAllocatedStorageEncrypted: !Ref DBStorageEncrypted
@@ -160,10 +165,19 @@ Resources:
         DBName: ''
         DBPort: '5432'
         EnableEventSubscription: 'false'
-        Subnet1ID: !Select [0, !Split [ ",", !ImportValue ATL-PriNets]]
-        Subnet2ID: !Select [1, !Split [ ",", !ImportValue ATL-PriNets]]
+        Subnet1ID: !Select
+          - 0
+          - !Split
+            - ","
+            - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+        Subnet2ID: !Select
+          - 1
+          - !Split
+            - ","
+            - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
         # NB: The VPCID is not used by the aurora template but it will fail if it is not provided.
-        VPCID: !ImportValue ATL-VPCID
+        VpcId:
+          Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
 
   PostgresDatabase:
     Type: AWS::CloudFormation::Stack
@@ -171,8 +185,8 @@ Resources:
     Properties:
       TemplateURL:
         !Sub
-          - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
-          - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
       Parameters:
         CustomDBSecurityGroup: !Ref DBSecurityGroup
         DBAllocatedStorage: !Ref DBAllocatedStorage
@@ -185,8 +199,17 @@ Resources:
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
         DBStorageType: !Ref DBStorageType
-        Subnet1ID: !Select [0, !Split [ ",", !ImportValue ATL-PriNets]]
-        Subnet2ID: !Select [1, !Split [ ",", !ImportValue ATL-PriNets]]
+        Subnet1ID: !Select
+          - 0
+          - !Split
+            - ","
+            - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+        Subnet2ID: !Select
+          - 1
+          - !Split
+            - ","
+            - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+
 
 Outputs:
   RDSEndPointAddress:

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -189,7 +189,7 @@ Resources:
       StorageType: !If [DBProvisionedIops, io1, gp2]
       Tags:
         - Key: Name
-          Value: !Sub ["${StackName} Confluence PostgreSQL Database", StackName: !Ref 'AWS::StackName']
+          Value: !Sub ["${StackName} PostgreSQL Database", StackName: !Ref 'AWS::StackName']
       VPCSecurityGroups: [!Ref CustomDBSecurityGroup]
 
 Outputs:

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -142,7 +142,7 @@ Resources:
             - s3
       Parameters:
         AvailabilityZones:
-          Fn::Join:
+          !Join
             - ','
             - !Ref 'AvailabilityZones'
         KeyPairName: !Ref 'KeyPairName'
@@ -191,3 +191,13 @@ Outputs:
   BastionPubIp:
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt 'BastionStack.Outputs.BastionPubIp'
+  NatGatewayIP1:
+    Description: Public IP for NAT gateway in Private Subnet 1
+    Value: !GetAtt VPCStack.Outputs.NAT1EIP
+    Export:
+      Name: !Sub '${ExportPrefix}NAT1EIP'
+  NatGatewayIP2:
+    Description: Public IP for NAT gateway in Private Subnet 2
+    Value: !GetAtt VPCStack.Outputs.NAT2EIP
+    Export:
+      Name: !Sub '${ExportPrefix}NAT2EIP'

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -31,7 +31,7 @@ Metadata:
       AvailabilityZones:
         default: Availability Zones
       ExportPrefix:
-        default: Export variable prefix
+        default: ASI identifier
       KeyPairName:
         default: Key Name
       NATInstanceType:
@@ -61,7 +61,7 @@ Parameters:
     Type: List<AWS::EC2::AvailabilityZone::Name>
   ExportPrefix:
     Default: ATL-
-    Description: Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS
+    Description: Identifier used in all variables exported from this deployment’s Atlassian Standard Infrastructure (VPCID, SubnetIDs, KeyName). Use different identifier to deploy multiple Atlassian Standard Infrastructures in the same AWS region.
       Quickstarts.
     Type: String
   KeyPairName:
@@ -69,8 +69,13 @@ Parameters:
       after it launches
     Type: AWS::EC2::KeyPair::KeyName
   NATInstanceType:
-    Default: t2.small
+    Default: t3.small
     AllowedValues:
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
       - t2.nano
       - t2.micro
       - t2.small
@@ -157,7 +162,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}quickstarts/quickstart-bastion-for-atlassian-services.yaml
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/quickstart-bastion-for-atlassian-services.yaml
         - QSS3Region: !If
             - GovCloudCondition
             - s3-us-gov-west-1


### PR DESCRIPTION
*Description of changes:*

* t2 family is not supported in some of the regions and caused taskcat to fail, I have switched the default to t3.micro and verified it is accessible in all regions
* I've also moved bastion template from quickstarts folder to templates (and deleted 
* Add support for ExportPrefix to quickstart-database-for-atlassian-services.yaml
* Use Network values from the exported values using the prefix
* Output Public NAT Gateway IPs (later used in the product templates for Security Group changes)
* Small reformatting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
