### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/quickstart-aws-vpc"]
 	path = submodules/quickstart-aws-vpc
-	url = ../../aws-quickstart/quickstart-aws-vpc.git
+	url = https://github.com/aws-quickstart/quickstart-aws-vpc.git
 [submodule "submodules/quickstart-amazon-aurora"]
 	path = submodules/quickstart-amazon-aurora
 	url = https://github.com/aws-quickstart/quickstart-amazon-aurora.git


### PR DESCRIPTION
Changing quickstart-aws-vpc URL to use absolute URL address

*Issue #, if available:*

*Description of changes:*
Changed submodule URL in quickstart-aws-vpc from relative URL to absolute URL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
