### PR TITLE
DCD-1006: Support for regional buckets

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: develop
+    upstream: aws-quickstart:develop
+    mergeMethod: hardreset

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *~
 *.bak
 /.idea
-.github
+/.github

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 *.bak
 /.idea
+.github

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *~
 *.bak
 /.idea
-/.github

--- a/ci/params/with-bucket-region/quickstart-with-bucket-region.json
+++ b/ci/params/with-bucket-region/quickstart-with-bucket-region.json
@@ -1,0 +1,30 @@
+[
+    {
+        "ParameterKey":"QSS3BucketName",
+        "ParameterValue":"$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey":"QSS3KeyPrefix",
+        "ParameterValue":"quickstart-atlassian-services/"
+    },
+    {
+        "ParameterKey":"QSS3BucketRegion",
+        "ParameterValue":"us-east-1"
+    },
+    {
+        "ParameterKey": "AvailabilityZones",
+        "ParameterValue": "$[taskcat_genaz_2]"
+    },
+    {
+        "ParameterKey": "AccessCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "ExportPrefix",
+        "ParameterValue": "$[taskcat_random-string]"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    }
+]

--- a/ci/params/with-bucket-region/taskcat.yml
+++ b/ci/params/with-bucket-region/taskcat.yml
@@ -18,7 +18,7 @@ global:
 
 tests:
   atlassian-vpc:
-    parameter_input: params/default/quickstart-asi-custom-export.json
+    parameter_input: params/with-bucket-region/quickstart-with-bucket-region.json
     template_file: quickstart-vpc-for-atlassian-services.yaml
     regions:
       - us-east-1

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -127,6 +127,10 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, and hyphens (-).
       It cannot start or end with a hyphen (-).
     Type: String
+  QSS3BucketRegion:
+    Default: ''
+    Type: String
+    Description: The AWS Region where the Quick Start S3 bucket is hosted. Do not update it unless you're using a custom Quick Start S3 bucket.
   QSS3KeyPrefix:
     Default: 'quickstart-atlassian-services/'
     AllowedPattern: ^[0-9a-zA-Z-/]*$
@@ -143,14 +147,19 @@ Parameters:
     Type: String
 
 Conditions:
+  GovCloudCondition: !Equals
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
   UseAurora:
     !Equals [!Ref DatabaseImplementation, 'Amazon Aurora PostgreSQL']
   UsePostgres:
     !Equals [!Ref DatabaseImplementation, 'PostgreSQL']
-  GovCloudCondition:
-    !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+  UsingDefaultBucket:
+    !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   UseDatabaseEncryption:
     !Equals [!Ref DBStorageEncrypted, true]
+  NoBucketRegionSupplied:
+    !Equals [!Ref QSS3BucketRegion, '']
 
 Mappings:    
   # Supported semantic version mappings taken from:
@@ -170,10 +179,16 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: UseAurora
     Properties:
-      TemplateURL:
-        !Sub
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
-        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      TemplateURL: !If
+        # Maintain backward compatibility for non-region support
+        - NoBucketRegionSupplied
+        - !Sub
+          - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
+          - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+        - !Sub
+          - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
+          - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+            S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
       Parameters:
         CustomDBSecurityGroup: !Ref DBSecurityGroup
         DBAllocatedStorageEncrypted: !Ref DBStorageEncrypted
@@ -209,10 +224,16 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: UsePostgres
     Properties:
-      TemplateURL:
-        !Sub
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
-        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      TemplateURL: !If
+        # Maintain backward compatibility for non-region support
+        - NoBucketRegionSupplied
+        - !Sub
+          - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
+          - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+        - !Sub
+          - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
+          - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+            S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
       Parameters:
         CustomDBSecurityGroup: !Ref DBSecurityGroup
         DBEngineVersion: !FindInMap [SemanticDBVersions, PostgreSQL, !Ref DBEngineVersion]
@@ -255,3 +276,27 @@ Outputs:
     Condition: UseDatabaseEncryption
     Description: The alias of the encryption key created for RDS
     Value: !If [UseAurora, !GetAtt AuroraDatabase.Outputs.RDSEncryptionKey, !GetAtt PostgresDatabase.Outputs.RDSEncryptionKey]
+  AuroraTemplateURL:
+    Condition: UseAurora
+    Description: The URL used to source the Aurora Stack template
+    Value: !If
+      - NoBucketRegionSupplied
+      - !Sub
+        - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
+        - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      - !Sub
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-amazon-aurora/templates/aurora_postgres.template.yaml
+        - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+  PostgresTemplateURL:
+    Condition: UsePostgres
+    Description: The URL used to source the PostgreSQL Stack template
+    Value: !If
+      - NoBucketRegionSupplied
+      - !Sub
+        - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
+        - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      - !Sub
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-postgres-for-atlassian-services.yaml
+        - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -28,6 +28,7 @@ Metadata:
         Parameters:
           - ExportPrefix
           - QSS3BucketName
+          - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
       AccessCIDR:
@@ -52,6 +53,8 @@ Metadata:
         default: Public Subnet 2 CIDR
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
+      QSS3BucketRegion:
+        default: Quick Start S3 bucket region
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
       VPCCIDR:
@@ -131,6 +134,10 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, and hyphens (-).
       It cannot start or end with a hyphen (-).
     Type: String
+  QSS3BucketRegion:
+    Default: ''
+    Type: String
+    Description: The AWS Region where the Quick Start S3 bucket is hosted. Do not update it unless you're using a custom Quick Start S3 bucket.
   QSS3KeyPrefix:
     Default: 'quickstart-atlassian-services/'
     AllowedPattern: ^[0-9a-zA-Z-/]*$
@@ -150,6 +157,11 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
+  UsingDefaultBucket:
+    !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  NoBucketRegionSuppliedOrBucketPrefixIsDefault: !Or
+    - !Equals [!Ref QSS3BucketRegion, '']
+    - !Equals [!Ref QSS3KeyPrefix, 'quickstart-atlassian-services/']
   KeyPairProvided:
     !Not [!Equals [!Ref KeyPairName, '']]
   ProvisionBastion: !And
@@ -160,12 +172,16 @@ Resources:
   VPCStack:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template
-        - QSS3Region: !If
-            - GovCloudCondition
-            - s3-us-gov-west-1
-            - s3
+      TemplateURL: !If
+        # Maintain backward compatibility for non-region support
+        - NoBucketRegionSuppliedOrBucketPrefixIsDefault
+        - !Sub
+          - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template
+          - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+        - !Sub
+          - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-aws-vpc/templates/aws-vpc.template
+          - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+            S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
       Parameters:
         AvailabilityZones:
           !Join
@@ -190,12 +206,16 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionBastion
     Properties:
-      TemplateURL: !Sub
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/quickstart-bastion-for-atlassian-services.yaml
-        - QSS3Region: !If
-            - GovCloudCondition
-            - s3-us-gov-west-1
-            - s3
+      TemplateURL: !If
+        # Maintain backward compatibility for non-region support
+        - NoBucketRegionSuppliedOrBucketPrefixIsDefault
+        - !Sub
+          - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/quickstart-bastion-for-atlassian-services.yaml
+          - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+        - !Sub
+          - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-bastion-for-atlassian-services.yaml
+          - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+            S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]    
       Parameters:
         AccessCIDR: !Ref AccessCIDR
         KeyName: !Ref 'KeyPairName'
@@ -244,3 +264,25 @@ Outputs:
     Value: !GetAtt VPCStack.Outputs.NAT2EIP
     Export:
       Name: !Sub '${ExportPrefix}NAT2EIP'
+  VpcTemplateURL:
+    Description: The URL used to source the VPC template
+    Value: !If
+      - NoBucketRegionSuppliedOrBucketPrefixIsDefault
+      - !Sub
+        - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template
+        - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      - !Sub
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/submodules/quickstart-aws-vpc/templates/aws-vpc.template
+        - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+  BastionTemplateURL:
+    Description: The URL used to source the Bastion template
+    Value: !If
+      - NoBucketRegionSuppliedOrBucketPrefixIsDefault
+      - !Sub
+        - https://${QSS3BucketName}.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/quickstart-bastion-for-atlassian-services.yaml
+        - S3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      - !Sub
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-bastion-for-atlassian-services.yaml
+        - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]  


### PR DESCRIPTION
⚠️ This change should be backward compatible and should not break existing templates when merged

As part of the rollout for QS versioning we need to support regional buckets. This will assist with two things:

- facilitate the move to an S3 SigV4 signing process
- Optimize latency, minimize costs, or address regulatory requirements, particularly with regards Government mandates on where data must reside. See here for more detail

This change will also be used as a driver for applying these changes to the other QS templates; Jira, Confluence and BitBucket