### PR TITLE
DCD-1051: Gov arn for gov region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *~
 *.bak
 /.idea
-.github
+/.github

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 *.bak
 /.idea
+.github

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *~
 *.bak
 /.idea
-/.github

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -138,6 +138,9 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
 
 Conditions:
+  GovCloudCondition: !Equals
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
   DBProvisionedIops:
     !Equals [!Ref DBStorageType, io1]
   UseDatabaseEncryption:
@@ -163,8 +166,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+              AWS: !Sub
+                - arn:${ArnPartition}:iam::${AWS::AccountId}:root
+                - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
             Action: 'kms:*'
             Resource: '*'
       Tags:
@@ -222,7 +226,9 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*"
+            Resource: !Sub
+              - arn:${ArnPartition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*
+              - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
   DB:
     Type: AWS::RDS::DBInstance
     Properties:


### PR DESCRIPTION
Ran custom Jira CI plan (temporarily updated Jira submodules to point to updated quickstart-atlassian-services and updated quickstart-amazon-aurora) results for which are below:

https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSJIRA64-JSMOKDEPLOY-9/log

Deploys passed and all but the HTTP acceptance tests which I believe to be a dud (looking at the logs). This run should confirm these AWS partition changes across the board for Jira and the other products; BB, Connie, Crowd

These changes have also been tested in a Gov account and are shown to work, where we no longer have failing deployments
