### PR TITLE
Output RDS Identifier from database templates

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -276,6 +276,9 @@ Outputs:
     Condition: UseDatabaseEncryption
     Description: The alias of the encryption key created for RDS
     Value: !If [UseAurora, !GetAtt AuroraDatabase.Outputs.RDSEncryptionKey, !GetAtt PostgresDatabase.Outputs.RDSEncryptionKey]
+  RDSIdentifier:
+    Description: The ID of the created resource, instance or cluster
+    Value: !If [UseAurora, !GetAtt AuroraDatabase.Outputs.DBClusterIdentifier, !GetAtt PostgresDatabase.Outputs.DBInstanceIdentifier]
   AuroraTemplateURL:
     Condition: UseAurora
     Description: The URL used to source the Aurora Stack template

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -262,3 +262,6 @@ Outputs:
     Condition: UseDatabaseEncryption
     Description: The alias of the encryption key created for RDS
     Value: !Ref EncryptionKeyAlias
+  DBInstanceIdentifier:
+    Description: "Database identifier"
+    Value: !Ref DB


### PR DESCRIPTION
*Description of changes:*

In quickstart-atlassian-bitbucket I found a bug that can be fixed by getting the RDS instance/cluster identifier directly. Therefore this template needs to output it, and depends on the Aurora child stack from this PR: https://github.com/aws-quickstart/quickstart-amazon-aurora-postgresql/pull/38

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
