### PR TITLE
DCD-1370 RDS DBAutoMinorVersionUpgrade default values are not consistent. Should be set to true by default

### DIFF
--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -185,9 +185,9 @@ Parameters:
     Type: String    
   DBAutoMinorVersionUpgrade: 
     AllowedValues: 
-      - "true"
-      - "false"
-    Default: "false"
+      - true
+      - false
+    Default: true
     Description: "Select true to set up auto minor version upgrade."
     Type: String
   DBBackupRetentionPeriod: 

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -30,9 +30,9 @@ Parameters:
     Default: ''
   DBAutoMinorVersionUpgrade:
     AllowedValues:
-      - "true"
-      - "false"
-    Default: "false"
+      - true
+      - false
+    Default: true
     Description: "Select true/false to setup Auto Minor Version upgrade. e.g. PostgreSQL 9.6.8 -> 9.6.11"
     Type: String
   DBBackupRetentionPeriod:


### PR DESCRIPTION
*DCD-1370*

*RDS DBAutoMinorVersionUpgrade set to true by default.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
